### PR TITLE
Dependencies upgrade and keyword arguments deprecation 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+DataFrames = "0.22, 1"
+GLM = "1.3, 2"
 julia = "1.0.5"
-DataFrames = "0.22"
-GLM = "1.3"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Y = X*B*transpose(Z)+E
 dat = RawData(Response(Y), Predictors(X, Z))
 ```
 
-Least-squares estimates for matrix linear models can be obtained by running `mlm`. An object of type `Mlm` will be returned, with variables for the coefficient estimates (`B`), the coefficient variance estimates (`varB`), and the estimated variance of the errors (`sigma`). By default, `mlm` estimates both row and column main effects (X and Z intercepts), but this behavior can be suppressed by setting `isXIntercept=false` and/or `isZntercept=false`. Column weights for `Y` and the target type for variance shrinkage<sup>[1](#myfootnote1)</sup> can be optionally supplied to `weights` and `targetType`, respectively. 
+Least-squares estimates for matrix linear models can be obtained by running `mlm`. An object of type `Mlm` will be returned, with variables for the coefficient estimates (`B`), the coefficient variance estimates (`varB`), and the estimated variance of the errors (`sigma`). By default, `mlm` estimates both row and column main effects (X and Z intercepts), but this behavior can be suppressed by setting `hasXIntercept=false` and/or `isZntercept=false`. Column weights for `Y` and the target type for variance shrinkage<sup>[1](#myfootnote1)</sup> can be optionally supplied to `weights` and `targetType`, respectively. 
 
 ```
 est = mlm(dat)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Y = X*B*transpose(Z)+E
 dat = RawData(Response(Y), Predictors(X, Z))
 ```
 
-Least-squares estimates for matrix linear models can be obtained by running `mlm`. An object of type `Mlm` will be returned, with variables for the coefficient estimates (`B`), the coefficient variance estimates (`varB`), and the estimated variance of the errors (`sigma`). By default, `mlm` estimates both row and column main effects (X and Z intercepts), but this behavior can be suppressed by setting `hasXIntercept=false` and/or `isZntercept=false`. Column weights for `Y` and the target type for variance shrinkage<sup>[1](#myfootnote1)</sup> can be optionally supplied to `weights` and `targetType`, respectively. 
+Least-squares estimates for matrix linear models can be obtained by running `mlm`. An object of type `Mlm` will be returned, with variables for the coefficient estimates (`B`), the coefficient variance estimates (`varB`), and the estimated variance of the errors (`sigma`). By default, `mlm` estimates both row and column main effects (X and Z intercepts), but this behavior can be suppressed by setting `hasXIntercept=false` and/or `hasZIntercept=false`. Column weights for `Y` and the target type for variance shrinkage<sup>[1](#myfootnote1)</sup> can be optionally supplied to `weights` and `targetType`, respectively. 
 
 ```
 est = mlm(dat)

--- a/src/MatrixLM.jl
+++ b/src/MatrixLM.jl
@@ -47,5 +47,4 @@ include("predict.jl")
 include("perm_pvals.jl")
 include("mlm_perms.jl")
 
-
 end 

--- a/src/data_types.jl
+++ b/src/data_types.jl
@@ -11,10 +11,10 @@ end
 
 
 """
-    Predictors(X, Z, isXIntercept, isZIntercept)
+    Predictors(X, Z, hasXIntercept, hasZIntercept)
 
 Type for storing predictor (covariate) matrices. Also stores boolean 
-variables isXIntercept and isZIntercept (if they are not supplied, they 
+variables hasXIntercept and hasZIntercept (if they are not supplied, they 
 default to false). 
 
 """
@@ -27,15 +27,15 @@ mutable struct Predictors
     Z::AbstractArray{Float64,2} 
     
     # Boolean flag indicating whether X has an intercept
-    isXIntercept::Bool 
+    hasXIntercept::Bool 
     # Boolean flag indicating whether Z has an intercept
-    isZIntercept::Bool 
+    hasZIntercept::Bool 
     
     # Usual constructor
-    Predictors(X, Z, isXIntercept, isZIntercept) = 
-        new(X, Z, isXIntercept, isZIntercept)
+    Predictors(X, Z, hasXIntercept, hasZIntercept) = 
+        new(X, Z, hasXIntercept, hasZIntercept)
     
-    # Modified constructor that sets isXIntercept and isZIntercept to false 
+    # Modified constructor that sets hasXIntercept and hasZIntercept to false 
     # by default
     Predictors(X, Z) = new(X, Z, false, false)
 end

--- a/src/mlm.jl
+++ b/src/mlm.jl
@@ -165,17 +165,24 @@ An Mlm object
 """
 function mlm(data::RawData; hasXIntercept::Bool=true, hasZIntercept::Bool=true, 
              weights=nothing, targetType=nothing, kwargs...)
-
-    if haskey(kwargs, :isXintercept)
-        @warn "Deprecated keyword arguments isXIntercept is now hasXIntercept."
-        hasXIntercept = kwargs[:isXIntercept]
-    end
-
-    if haskey(kwargs, :isZintercept)
-        @warn "Deprecated keyword arguments isZIntercept is now hasZIntercept."
-        hasZIntercept = kwargs[:isZIntercept]
-    end
     
+    #= Deprecation:check for previous version keyword arguments
+    ---------------------------------------------------------------------------------------------=#
+    if haskey(kwargs, :isXIntercept)
+        Base.depwarn("Keyword arguments `isXIntercept` and `isZIntercept` are deprecated, use 
+                    `hasXIntercept` and `hasZIntercept` instead.", 
+                    :mlm, force=true)
+        hasXIntercept = values(kwargs).isXIntercept
+    end
+
+    if haskey(kwargs, :isZIntercept)
+        Base.depwarn("Keyword arguments `isXIntercept` and `isZIntercept` are deprecated, use 
+                    `hasXIntercept` and `hasZIntercept` instead.", 
+                    :mlm, force=true)
+        hasZIntercept = values(kwargs).isZIntercept
+    end
+    #-----------------------------------------------------------------------------------------------
+
     # Add X and Z intercepts if necessary
     if hasXIntercept==true && data.predictors.hasXIntercept==false
         data.predictors.X = add_intercept(data.predictors.X)

--- a/src/mlm_perms.jl
+++ b/src/mlm_perms.jl
@@ -1,5 +1,5 @@
 """
-    mlm_perms(data, nPerms; permFun, isXIntercept, isZIntercept, 
+    mlm_perms(data, nPerms; permFun, hasXIntercept, hasZIntercept, 
               weights, targetType, isMainEff)
 
 Obtains permutation p-values for MLM t-statistics. 
@@ -13,9 +13,9 @@ Obtains permutation p-values for MLM t-statistics.
 
 - permFun = function used to permute `Y`. Defaults to `shuffle_rows` 
   (shuffles rows of `Y`). 
-- isXIntercept = boolean flag indicating whether or not to include an `X` 
+- hasXIntercept = boolean flag indicating whether or not to include an `X` 
   intercept (row main effects). Defaults to `true`. 
-- isZIntercept = boolean flag indicating whether or not to include a `Z` 
+- hasZIntercept = boolean flag indicating whether or not to include a `Z` 
   intercept (column main effects). Defaults to `true`. 
 - weights = 1d array of floats to use as column weights for `Y`, or `nothing`. 
   If the former, must be the same length as the number of columns of `Y`. 
@@ -43,13 +43,13 @@ Permutations are computed in parallel when possible.
 """
 function mlm_perms(data::RawData, nPerms::Int64=1000; 
                    permFun::Function=shuffle_rows, 
-                   isXIntercept::Bool=true, isZIntercept::Bool=true, 
+                   hasXIntercept::Bool=true, hasZIntercept::Bool=true, 
                    weights=nothing, targetType=nothing, isMainEff::Bool=false) 
     
     # Wrapper function that performs MLM and gets t-statistics
     function mlm_t_stat(data::RawData)
-        return t_stat(mlm(data; isXIntercept=isXIntercept, 
-                      isZIntercept=isZIntercept, weights=weights, 
+        return t_stat(mlm(data; hasXIntercept=hasXIntercept, 
+                      hasZIntercept=hasZIntercept, weights=weights, 
                       targetType=targetType), isMainEff)
     end
     

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -37,30 +37,30 @@ Response object
 function predict(MLM::Mlm, newPredictors::Predictors=MLM.data.predictors)
     
   	# Include X and Z intercepts in new data if necessary
-  	if MLM.data.predictors.isXIntercept==true && 
-       newPredictors.isXIntercept==false
+  	if MLM.data.predictors.hasXIntercept==true && 
+       newPredictors.hasXIntercept==false
     	newPredictors.X = add_intercept(newPredictors.X)
-    	newPredictors.isXIntercept = true
+    	newPredictors.hasXIntercept = true
     	println("Adding X intercept to newPredictors.")
   	end
-  	if MLM.data.predictors.isZIntercept==true && 
-       newPredictors.isZIntercept==false
+  	if MLM.data.predictors.hasZIntercept==true && 
+       newPredictors.hasZIntercept==false
     	newPredictors.Z = add_intercept(newPredictors.Z)
-    	newPredictors.isZIntercept = true
+    	newPredictors.hasZIntercept = true
     	println("Adding Z intercept to newPredictors.")
   	end
     
   	# Remove X and Z intercepts in new data if necessary
-  	if MLM.data.predictors.isXIntercept==false && 
-       newPredictors.isXIntercept==true
+  	if MLM.data.predictors.hasXIntercept==false && 
+       newPredictors.hasXIntercept==true
     	newPredictors.X = remove_intercept(newPredictors.X)
-    	newPredictors.isXIntercept = false
+    	newPredictors.hasXIntercept = false
     	println("Removing X intercept from newPredictors.")
   	end
-  	if MLM.data.predictors.isZIntercept==false && 
-       newPredictors.isZIntercept==true
+  	if MLM.data.predictors.hasZIntercept==false && 
+       newPredictors.hasZIntercept==true
     	newPredictors.Z = remove_intercept(newPredictors.Z)
-    	newPredictors.isZIntercept = false
+    	newPredictors.hasZIntercept = false
     	println("Removing Z intercept from newPredictors.")
   	end
     
@@ -109,33 +109,33 @@ Calculates residuals of an Mlm object
 function resid(MLM::Mlm, newData::RawData=MLM.data)
     
     # Include X and Z intercepts in new data if necessary
-    if MLM.data.predictors.isXIntercept==true && 
-       newData.predictors.isXIntercept==false
+    if MLM.data.predictors.hasXIntercept==true && 
+       newData.predictors.hasXIntercept==false
         newData.predictors.X = add_intercept(newData.predictors.X)
-        newData.predictors.isXIntercept = true
+        newData.predictors.hasXIntercept = true
         newData.p = newData.p + 1
         println("Adding X intercept to newData.")
     end
-    if MLM.data.predictors.isZIntercept==true && 
-       newData.predictors.isZIntercept==false
+    if MLM.data.predictors.hasZIntercept==true && 
+       newData.predictors.hasZIntercept==false
         newData.predictors.Z = add_intercept(newData.predictors.Z)
-        newData.predictors.isZIntercept = true
+        newData.predictors.hasZIntercept = true
         newData.q = newData.q + 1
         println("Adding Z intercept to newData.")
     end
     
     # Remove X and Z intercepts in new data if necessary
-    if MLM.data.predictors.isXIntercept==false && 
-       newData.predictors.isXIntercept==true
+    if MLM.data.predictors.hasXIntercept==false && 
+       newData.predictors.hasXIntercept==true
         newData.predictors.X = remove_intercept(newData.predictors.X)
-        newData.predictors.isXIntercept = false
+        newData.predictors.hasXIntercept = false
         newData.p = newData.p - 1
         println("Removing X intercept from newData.")
     end
-    if MLM.data.predictors.isZIntercept==false && 
-       newData.predictors.isZIntercept==true
+    if MLM.data.predictors.hasZIntercept==false && 
+       newData.predictors.hasZIntercept==true
         newData.predictors.Z = remove_intercept(newData.predictors.Z)
-        newData.predictors.isZIntercept = false
+        newData.predictors.hasZIntercept = false
         newData.q = newData.q - 1
         println("Removing Z intercept from newData.")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,15 +26,15 @@ using GLM
     Y = X*B*transpose(Z)+E
     
     # Data frame to be passed into lm
-    GLMData = DataFrame(hcat(vec(Y), kron(Z,X)))
+    GLMData = DataFrame(hcat(vec(Y), kron(Z,X)), :auto)
     # lm estimate
-    GLMEst = lm(convert(Array{Float64, 2}, GLMData[:,2:end]), 
-                convert(Array{Float64, 1}, GLMData[:,1]))
+    GLMEst = lm(Matrix(GLMData[:,2:end]), Vector(GLMData[:,1]))
     
     # Put together RawData object for MLM
     MLMData = RawData(Response(Y), Predictors(X, Z))
     # mlm estimate
-    MLMEst = mlm(MLMData, hasXIntercept = false, hasZIntercept = false)
+    # MLMEst = mlm(MLMData, hasXIntercept = false, hasZIntercept = false)
+    MLMEst = mlm(MLMData, isXIntercept = false, isZIntercept = false)
     
     @test isapprox(GLM.coef(GLMEst), vec(MatrixLM.coef(MLMEst)), atol=tol)
     @test isapprox(GLM.predict(GLMEst), vec(MatrixLM.predict(MLMEst).Y), atol=tol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,7 @@ using GLM
     # Put together RawData object for MLM
     MLMData = RawData(Response(Y), Predictors(X, Z))
     # mlm estimate
-    MLMEst = mlm(MLMData, isXIntercept = false, isZIntercept = false)
+    MLMEst = mlm(MLMData, hasXIntercept = false, hasZIntercept = false)
     
     @test isapprox(GLM.coef(GLMEst), vec(MatrixLM.coef(MLMEst)), atol=tol)
     @test isapprox(GLM.predict(GLMEst), vec(MatrixLM.predict(MLMEst).Y), atol=tol)


### PR DESCRIPTION
- Update versions of the dependencies compatibility for `DataFrames.jl` and `GLM.jl`.

- Keyword arguments `isXIntercept` and `isZIntercept` are deprecated, use `hasXIntercept` and `hasZIntercept` instead."