### PR TITLE
 v0.3.0

### DIFF
--- a/src/MatrixLM.jl
+++ b/src/MatrixLM.jl
@@ -34,7 +34,7 @@ module MatrixLM
 
     # Miscellenous helper functions
     include("misc_helpers.jl")
-    export add_intercept, remove_intercept, shuffle_rows, shuffle_cols, is_full_rank, check_Z_rank
+    export add_intercept, remove_intercept,shuffle_rows, shuffle_cols, is_full_rank, check_Z_rank
 
     # Matrix linear model helper functions
     include("mlm_helpers.jl")

--- a/test/design_matrix_test.jl
+++ b/test/design_matrix_test.jl
@@ -27,6 +27,18 @@ mat_1 = MatrixLM.design_matrix(
 	my_contrasts,
 )
 
+my_contrasts_vec = [
+	(:catvar1, DummyCoding()),
+	(:catvar2, EffectsCoding(base = "A")),
+	(:catvar3, DummyCoding(base = "E")),
+]
+
+mat_1_vec = MatrixLM.design_matrix(
+	@mlmformula(1 + catvar1 + catvar2 + catvar3 + var1 + var2 + var3 + var4),
+	X_df,
+	my_contrasts_vec,
+)
+
 # design matrix including only categorical without spcifying my_contrasts
 # default is dummy coded
 mat_2 = MatrixLM.design_matrix(
@@ -61,6 +73,9 @@ mat_2_terms = MatrixLM.design_matrix_names(
 	# test the dimension of the matrix after the design_matrix transformation with the one from StatsModels
 	@test size(mat_1) == (100, 10)
 	@test size(mat_2) == (100, 5)
+
+	# test the vector-based contrast specification matches the dictionary version
+	@test mat_1_vec == mat_1
 
 	# test the names of the columns of the design matrix
 	@test mat_1_terms == ["(Intercept)",

--- a/test/mlm_test.jl
+++ b/test/mlm_test.jl
@@ -35,6 +35,9 @@ MLMData_w = RawData(Response(Yw), Predictors(X, Z))
 # mlm estimate
 # MLMEst = mlm(MLMData, addXIntercept = false, addZIntercept = false)
 MLMEst = mlm(MLMData, addXIntercept = false, addZIntercept = false)
+
+# Function to run matrix linear model on a fresh copy of the data
+fresh_raw() = RawData(Response(copy(Y)), Predictors(copy(X), copy(Z)))
     
 @testset "testmlm" begin
     @test isapprox(GLM.coef(GLMEst), vec(MatrixLM.coef(MLMEst)), atol=tol)
@@ -53,3 +56,30 @@ GLMEst_w = lm(Matrix(GLMData_w[:,2:end]), Vector(GLMData_w[:,1]))
     @test LinearAlgebra.issymmetric(round.(MLMEst_w.sigma, digits=10))
     #@test isapprox(GLM.coef(GLMEst_w), vec(MatrixLM.coef(MLMEst_w)), atol=tol)
 end;
+
+
+@testset "tStatTest" begin
+    # test t statistics with and without main effects, and with only one intercept
+    MLM_intercepts = mlm(fresh_raw(), addXIntercept = true, addZIntercept = true)
+    t_no_main = MatrixLM.t_stat(MLM_intercepts)
+    expected_no_main = MLM_intercepts.B[2:end, 2:end] ./ sqrt.(MLM_intercepts.varB[2:end, 2:end])
+    @test size(t_no_main) == size(expected_no_main)
+    @test t_no_main ≈ expected_no_main atol = tol
+
+    # test with main effects included
+    t_with_main = MatrixLM.t_stat(MLM_intercepts, true)
+    expected_with_main = MLM_intercepts.B ./ sqrt.(MLM_intercepts.varB)
+    @test t_with_main ≈ expected_with_main atol = tol
+
+    # test with only one intercept included
+    MLM_x_only = mlm(fresh_raw(), addXIntercept = true, addZIntercept = false)
+    t_x_only = MatrixLM.t_stat(MLM_x_only)
+    expected_x_only = MLM_x_only.B[2:end, :] ./ sqrt.(MLM_x_only.varB[2:end, :])
+    @test t_x_only ≈ expected_x_only atol = tol
+
+    # test with only Z intercept included
+    MLM_z_only = mlm(fresh_raw(), addXIntercept = false, addZIntercept = true)
+    t_z_only = MatrixLM.t_stat(MLM_z_only)
+    expected_z_only = MLM_z_only.B[:, 2:end] ./ sqrt.(MLM_z_only.varB[:, 2:end])
+    @test t_z_only ≈ expected_z_only atol = tol
+end


### PR DESCRIPTION

v0.3.0
- addXintercept=false / addZintercept=false now preserve existing intercept columns.
- updated weighted functions
- removed deprecation warnings for the intercept keywords.
- added new tests (calc_predicts!, calc_resid!, design_matrix, t_stat)
