### PR TITLE
improvements to CI and Julia-ness

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,8 +8,11 @@ jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,43 +10,32 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         version:
-          - '1.10.10'
+          - 'min'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:
           - ubuntu-latest
-        arch:
-          - x64
         include:
           - os: windows-latest
             version: '1'
-            arch: x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_NUM_THREADS: 4
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
-          file: lcov.info
+          files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,24 +10,24 @@ on:
   pull_request:
 
 jobs:
-  build:
+  Documenter:
+    name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      statuses: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
-      - uses: julia-actions/julia-buildpkg@v1
+      - uses: actions/checkout@v6 # v6
         with:
-          version: '1'
-      - name: Install dependencies
-        run: julia --project=docs/ -e '
-             using Pkg;
-             Pkg.develop(PackageSpec(path=pwd()));
-             Pkg.add("Documenter");
-             Pkg.instantiate()'
-
-      - name: Build and deploy
-        run: julia --project=docs docs/make.jl
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: 1
+      - name: Cache
+        uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1 
+      - uses: julia-actions/julia-docdeploy@v1
         env:
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # when run by tagbot
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
           DOCUMENTER_DEBUG: true

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatrixLM"
 uuid = "37290134-6146-11e9-0c71-a5c489be1f53"
-authors = ["Jane Liang", "Gregory Farage", "Chenhao Zhao", "Saunak Sen"]
 version = "0.3.1"
+authors = ["Jane Liang", "Gregory Farage", "Chenhao Zhao", "Saunak Sen"]
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -11,6 +11,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
@@ -23,6 +24,7 @@ LinearAlgebra = "1"
 Random = "1"
 SharedArrays = "1"
 Statistics = "1"
+StatsAPI = "1.8.0"
 StatsModels = "0.6, 0.7"
 Test = "1"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatrixLM"
 uuid = "37290134-6146-11e9-0c71-a5c489be1f53"
 version = "0.3.1"
-authors = ["Jane Liang, Gregory Farage, Chenhao Zhao, Saunak Sen"]
+authors = ["Jane Liang", "Gregory Farage", "Chenhao Zhao", "Saunak Sen"]
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatrixLM"
 uuid = "37290134-6146-11e9-0c71-a5c489be1f53"
-version = "0.3.1"
 authors = ["Jane Liang", "Gregory Farage", "Chenhao Zhao", "Saunak Sen"]
+version = "0.3.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -17,7 +17,7 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 Aqua = "0.8"
 DataFrames = "0.22, 1"
 Distributed = "1"
-Distributions = "0.25.122"
+Distributions = "0.25"
 GLM = "1.8"
 LinearAlgebra = "1"
 Random = "1"
@@ -25,7 +25,7 @@ SharedArrays = "1"
 Statistics = "1"
 StatsModels = "0.6, 0.7"
 Test = "1"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -14,15 +14,23 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
+Aqua = "0.8"
 DataFrames = "0.22, 1"
+Distributed = "1"
 Distributions = "0.25.122"
+GLM = "1.8"
+LinearAlgebra = "1"
+Random = "1"
+SharedArrays = "1"
 Statistics = "1"
-StatsModels = "0.6, 0.7, 1"
+StatsModels = "0.6, 0.7"
+Test = "1"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["GLM", "Test"]
+test = ["Aqua", "GLM", "Test"]

--- a/docs/src/example_ordinal_data.md
+++ b/docs/src/example_ordinal_data.md
@@ -140,7 +140,7 @@ est = mlm(dat; addXIntercept=false, addZIntercept=false); # Model estimation
 ## Model predictions and residuals
 
 
-The coefficient estimates can be accessed using `coef(est)`. Predicted values and residuals can be obtained by calling `predict()` and `resid()`. By default, both of these functions use the same data used to fit the model. However, a new `Predictors` object can be passed into `predict()` as the `newPredictors` argument, and a new `RawData` object can be passed into `resid()` as the newData argument. For convenience, `fitted(est)` will return the fitted values by calling predict with the default arguments.  
+The coefficient estimates can be accessed using `coef(est)`. Predicted values and residuals can be obtained by calling `predict()` and `residuals()`. By default, both of these functions use the same data used to fit the model. However, a new `Predictors` object can be passed into `predict()` as the `newPredictors` argument, and a new `RawData` object can be passed into `residuals()` as the newData argument. For convenience, `fitted(est)` will return the fitted values by calling predict with the default arguments.  
   
 To compare the estimated coefficients with the original matrix `B`, we will visualize the matrices using heatmaps. This graphical representation allows us to see the differences and similarities between the two readily.
 
@@ -173,10 +173,10 @@ plot(
 )
 ```
 
-The `resid()` function, available in `MatrixLM.jl`, computes residuals for each observation, helping you evaluate the discrepancy between the model's predictions and the observed data.
+The `residuals()` function, available in `MatrixLM.jl`, computes residuals for each observation, helping you evaluate the discrepancy between the model's predictions and the observed data.
 
 ```@example
-resids = resid(est);
+resids = residuals(est);
 
 plot(
     heatmap(resids[end:-1:1, :], 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -134,7 +134,7 @@ nothing #hide
 ## Model predictions and residuals
 
 
-The coefficient estimates can be accessed using `coef(est)`. Predicted values and residuals can be obtained by calling `predict()` and `resid()`. By default, both of these functions use the same data used to fit the model. However, a new `Predictors` object can be passed into `predict()` as the `newPredictors` argument, and a new `RawData` object can be passed into `resid()` as the newData argument. For convenience, `fitted(est)` will return the fitted values by calling predict with the default arguments.   
+The coefficient estimates can be accessed using `coef(est)`. Predicted values and residuals can be obtained by calling `predict()` and `residuals()`. By default, both of these functions use the same data used to fit the model. However, a new `Predictors` object can be passed into `predict()` as the `newPredictors` argument, and a new `RawData` object can be passed into `residuals()` as the newData argument. For convenience, `fitted(est)` will return the fitted values by calling predict with the default arguments.   
 
 To compare the estimated coefficients with the original matrix `B`, we will visualize the matrices using heatmaps. This graphical representation allows us to readily see differences and similarities between the two.
 
@@ -168,10 +168,10 @@ plot(
 )
 ```
 
-The `resid()` function, available in `MatrixLM.jl`, computes residuals for each observation, helping you evaluate the discrepancy between the model's predictions and the observed data.
+The `residuals()` function, available in `MatrixLM.jl`, computes residuals for each observation, helping you evaluate the discrepancy between the model's predictions and the observed data.
 
 ```@example
-resids = resid(est);
+resids = residuals(est);
 
 plot(
     heatmap(resids[end:-1:1, :], 
@@ -241,4 +241,3 @@ MatrixLM.summary(est, alpha = 0.05, permutation_test = false)
 
 
 [^1]: Ledoit, O., & Wolf, M. (2003). Improved estimation of the covariance matrix of stock returns with an application to portfolio selection. Journal of empirical finance, 10(5), 603-621. 
-

--- a/notebooks/example_ordinal_data.ipynb
+++ b/notebooks/example_ordinal_data.ipynb
@@ -255,7 +255,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The coefficient estimates can be accessed using `coef(est)`. Predicted values and residuals can be obtained by calling `predict()` and `resid()`. By default, both of these functions use the same data used to fit the model. However, a new `Predictors` object can be passed into `predict()` as the `newPredictors` argument, and a new `RawData` object can be passed into `resid()` as the newData argument. For convenience, `fitted(est)` will return the fitted values by calling predict with the default arguments.  \n",
+    "The coefficient estimates can be accessed using `coef(est)`. Predicted values and residuals can be obtained by calling `predict()` and `residuals()`. By default, both of these functions use the same data used to fit the model. However, a new `Predictors` object can be passed into `predict()` as the `newPredictors` argument, and a new `RawData` object can be passed into `residuals()` as the newData argument. For convenience, `fitted(est)` will return the fitted values by calling predict with the default arguments.  \n",
     "  \n",
     "To compare the estimated coefficients with the original matrix `B`, we will visualize the matrices using heatmaps. This graphical representation allows us to see the differences and similarities between the two readily."
    ]
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `resid()` function, available in `MatrixLM.jl`, computes residuals for each observation, helping you evaluate the discrepancy between the model's predictions and the observed data."
+    "The `residuals()` function, available in `MatrixLM.jl`, computes residuals for each observation, helping you evaluate the discrepancy between the model's predictions and the observed data."
    ]
   },
   {
@@ -318,7 +318,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resids = resid(est);\n",
+    "resids = residuals(est);\n",
     "\n",
     "plot(\n",
     "    heatmap(resids[end:-1:1, :], \n",

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -222,7 +222,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The coefficient estimates can be accessed using `coef(est)`. Predicted values and residuals can be obtained by calling `predict()` and `resid()`. By default, both of these functions use the same data used to fit the model. However, a new `Predictors` object can be passed into `predict()` as the `newPredictors` argument, and a new `RawData` object can be passed into `resid()` as the newData argument. For convenience, `fitted(est)` will return the fitted values by calling predict with the default arguments.   \n",
+    "The coefficient estimates can be accessed using `coef(est)`. Predicted values and residuals can be obtained by calling `predict()` and `residuals()`. By default, both of these functions use the same data used to fit the model. However, a new `Predictors` object can be passed into `predict()` as the `newPredictors` argument, and a new `RawData` object can be passed into `residuals()` as the newData argument. For convenience, `fitted(est)` will return the fitted values by calling predict with the default arguments.   \n",
     "\n",
     "To compare the estimated coefficients with the original matrix `B`, we will visualize the matrices using heatmaps. This graphical representation allows us to readily see differences and similarities between the two."
    ]
@@ -277,7 +277,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `resid()` function, available in `MatrixLM.jl`, computes residuals for each observation, helping you evaluate the discrepancy between the model's predictions and the observed data."
+    "The `residuals()` function, available in `MatrixLM.jl`, computes residuals for each observation, helping you evaluate the discrepancy between the model's predictions and the observed data."
    ]
   },
   {
@@ -286,7 +286,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resids = resid(est);\n",
+    "resids = residuals(est);\n",
     "\n",
     "plot(\n",
     "    heatmap(resids[end:-1:1, :], \n",

--- a/src/MatrixLM.jl
+++ b/src/MatrixLM.jl
@@ -6,7 +6,7 @@ module MatrixLM
     import LinearAlgebra.I, LinearAlgebra.mul!, 
            LinearAlgebra.diag, LinearAlgebra.diagm
     using DataFrames
-    
+    using StatsAPI: StatsAPI, predict, residuals, coef, fitted, confint
 
     # Data object types
     include("data_types.jl")
@@ -45,11 +45,11 @@ module MatrixLM
 
     # # Estimate extraction
     include("summary.jl")
-    export confint,summary
+    export confint, summary
 
     # Predictions and residuals
     include("predict.jl")
-    export coef, predict, fitted, resid
+    export coef, predict, fitted, residuals
 
     # Permutations
     include("perm_pvals.jl")

--- a/src/calc_resid.jl
+++ b/src/calc_resid.jl
@@ -2,7 +2,7 @@
     calc_resid(X::AbstractArray{Float64,2}, Y::AbstractArray{Float64,2}, 
            Z::AbstractArray{Float64,2}, B::AbstractArray{Float64,2})
 
-Calculate residuals
+Calculate resid
 
 # Arguments 
 
@@ -23,7 +23,7 @@ function calc_resid(X::AbstractArray{Float64,2}, Y::AbstractArray{Float64,2},
     # Obtain fitted values
     resid = calc_preds(X, Z, B) 
     
-    # Compute residuals over fitted values
+    # Compute resid over fitted values
     resid .= Y .- resid
     
     return resid
@@ -37,11 +37,11 @@ end
                      Z::AbstractArray{Float64,2}, 
                      B::AbstractArray{Float64,2})
 
-Calculate residuals in place
+Calculate resid in place
 
 # Arguments 
 
-- `resid`: 2d array of floats consisting of the residuals, to be updated in 
+- `resid`: 2d array of floats consisting of the resid, to be updated in 
   place
 - `X`: 2d array of floats consisting of the row covariates, standardized as 
   necessary

--- a/src/mlm.jl
+++ b/src/mlm.jl
@@ -59,7 +59,7 @@ function mlm_fit(data::RawData, weights::Nothing, targetType)
     # Estimate MLM coefficients
     B = calc_coeffs(get_X(data), get_Y(data), get_Z(data), XᵀX, ZᵀZ) 
     
-    # Calculate residuals 
+    # Calculate resid 
     resid = calc_resid(get_X(data), get_Y(data), get_Z(data), B)
     
     # Estimate variance of errors, optionally with variance shrinkage
@@ -118,7 +118,7 @@ function mlm_fit(data::RawData, weights::Array{Float64,1}, targetType)
     # Estimate MLM coefficients
     B = calc_coeffs(get_X(data), get_Y(data), WZ, XᵀX, ZᵀWZ)
     
-    # Calculate residuals 
+    # Calculate resid 
     resid = calc_resid(get_X(data), get_Y(data), get_Z(data), B)
     
     # Estimate variance of errors, optionally with variance shrinkage

--- a/src/mlm_helpers.jl
+++ b/src/mlm_helpers.jl
@@ -37,7 +37,7 @@ shrinkage.
 
 # Arguments
 
-- `resid::AbstractArray{Float64,2}:` 2d array of floats consisting of the residuals
+- `resid::AbstractArray{Float64,2}:` 2d array of floats consisting of the resid
 - `targetType` : `nothing`
 
 # Value
@@ -71,7 +71,7 @@ shrinkage.
 
 # Arguments
 
-- `resid::AbstractArray{Float64,2}`: 2d array of floats consisting of the residuals
+- `resid::AbstractArray{Float64,2}`: 2d array of floats consisting of the resid
 - `targetType::AbstractString`: Indicating the target type toward which to shrink the 
   variance. Acceptable inputs are "A", "B", "C", and "D". 
     - "A": Target is identity matrix

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -12,7 +12,7 @@ Extracts coefficients from Mlm object
 2d array of floats
 
 """
-function coef(MLM::Mlm)
+function StatsAPI.coef(MLM::Mlm)
     
     return MLM.B
 end
@@ -34,7 +34,7 @@ Calculates new predictions based on Mlm object
 Response object
 
 """
-function predict(MLM::Mlm, newPredictors::Predictors=MLM.data.predictors)
+function StatsAPI.predict(MLM::Mlm, newPredictors::Predictors=MLM.data.predictors)
     
   	# Include X and Z intercepts in new data if necessary
   	if MLM.data.predictors.hasXIntercept==true && 
@@ -83,7 +83,7 @@ Calculate fitted values of an Mlm object
 Response object
 
 """
-function fitted(MLM::Mlm)
+function StatsAPI.fitted(MLM::Mlm)
     
     # Call the predict function with default newPredictors
     return predict(MLM)
@@ -91,7 +91,7 @@ end
 
 
 """
-    resid(MLM::Mlm, newData::RawData=MLM.data)
+    residuals(MLM::Mlm, newData::RawData=MLM.data)
 
 Calculates residuals of an Mlm object
 
@@ -106,7 +106,7 @@ Calculates residuals of an Mlm object
 2d array of floats
 
 """
-function resid(MLM::Mlm, newData::RawData=MLM.data)
+function StatsAPI.residuals(MLM::Mlm, newData::RawData=MLM.data)
     
     # Include X and Z intercepts in new data if necessary
     if MLM.data.predictors.hasXIntercept==true && 

--- a/src/shrink_sigma.jl
+++ b/src/shrink_sigma.jl
@@ -109,7 +109,7 @@ Ledoit, O., & Wolf, M. (2003). Improved estimation of the covariance matrix
 """
 function shrink_sigma(resid::AbstractArray{Float64,2}, targetType::String)
     
-    # Dimensions of resid
+    # Dimensions of residuals
     (n, p) = size(resid)
     
     # Estimates and the variance of the error variance

--- a/src/summary.jl
+++ b/src/summary.jl
@@ -14,11 +14,11 @@ estimated coefficients in a fitted matrix linear model.
 DataFrame with columns `coefficient`, `ci_lower`, `ci_upper`, and `margin_of_error` for each
 coefficient.
 """
-function confint(mlm_est::Mlm; alpha::Float64 = 0.05)
+function StatsAPI.confint(mlm_est::Mlm; alpha::Float64 = 0.05)
 
 
     # Flatten MLM outputs to save into a dataframe
-    est_coef = MatrixLM.coef(mlm_est) |> vec
+    est_coef = coef(mlm_est) |> vec
     var_est = mlm_est.varB |> vec
     se = sqrt.(var_est)
 
@@ -63,7 +63,7 @@ function summary(mlm_est::Mlm;
     alpha::Float64 = 0.05, permutation_test::Bool = false, nPerms::Int = 500)
 
     # Flatten MLM outputs to save into a dataframe
-    est_coef = MatrixLM.coef(mlm_est) |> vec
+    est_coef = coef(mlm_est) |> vec
     var_est = mlm_est.varB  |> vec
     se = sqrt.(var_est)
 
@@ -72,7 +72,7 @@ function summary(mlm_est::Mlm;
     col_term = ["col_" * string(j) for j in 1:mlm_est.data.q for i in 1:mlm_est.data.p]
     
     # Get confidence intervals
-    confint = MatrixLM.confint(mlm_est; alpha = alpha)
+    confint_df = confint(mlm_est; alpha = alpha)
 
     # Get t-statistics and p-values
     if permutation_test == true
@@ -89,7 +89,7 @@ function summary(mlm_est::Mlm;
         std_error = se,
         t_stat = tStatsOut |> vec,
         p_value = pvalues |> vec,
-        ci_lower = confint.ci_lower,
-        ci_upper = confint.ci_upper,
+        ci_lower = confint_df.ci_lower,
+        ci_upper = confint_df.ci_upper,
     )
 end

--- a/test/predict_test.jl
+++ b/test/predict_test.jl
@@ -31,19 +31,19 @@ MLMData = RawData(Response(Y), Predictors(X, Z));
 
 # Estimate Ŷpredict with X, Z intercept
 MLMEst = mlm(MLMData, addXIntercept = true, addZIntercept = true) # WARNING IT CHANGES INTERCEPT IN ORGINAL MLMData
-Ŷpredict_a = MatrixLM.predict(MLMEst).Y
-Ŷfitted = MatrixLM.fitted(MLMEst).Y
-residuals = resid(MLMEst, RawData(Response(Y),Predictors(X,Z,false,false)))
-default_resids = resid(MLMEst)
+Ŷpredict_a = predict(MLMEst).Y
+Ŷfitted = fitted(MLMEst).Y
+resids = residuals(MLMEst, RawData(Response(Y),Predictors(X,Z,false,false)))
+default_resids = residuals(MLMEst)
 
 @testset "predictTesting" begin   
     # testing the dimension of fitted y with actual Y, to see their consistancy
     @test sizeof(Ŷpredict_a) == sizeof(Y)
     @test sizeof(Ŷfitted) == sizeof(Y)
     @test isapprox(Ŷpredict_a, Ŷfitted, atol=tol)
-    # testing the calc_preds function, too see if they are identical with the resid function
-    @test MatrixLM.calc_resid(get_X(MLMEst.data), get_Y(MLMEst.data), get_Z(MLMEst.data),MatrixLM.coef(MLMEst)) == resid(MLMEst)
-    @test default_resids == residuals    
+    # testing the calc_preds function, too see if they are identical with the residuals function
+    @test MatrixLM.calc_resid(get_X(MLMEst.data), get_Y(MLMEst.data), get_Z(MLMEst.data),MatrixLM.coef(MLMEst)) == residuals(MLMEst)
+    @test default_resids == resids    
 end
 
 ###############################################
@@ -62,8 +62,8 @@ Ŷpredict2 = MatrixLM.predict(MLMEst, Predictors(X,Z,false, false)).Y
 # Estimate Ŷpredict without X, Z intercept
 MLMEst = mlm(MLMData, addXIntercept = false, addZIntercept = false)
 Ŷpredict_b = MatrixLM.predict(MLMEst).Y
-default_resids = resid(MLMEst)
-residuals2 = resid(MLMEst, RawData(Response(Y),Predictors(hcat(ones(size(X, 1)), X), hcat(ones(size(Z, 1)), Z),true, true)))
+default_resids = residuals(MLMEst)
+resids2 = residuals(MLMEst, RawData(Response(Y),Predictors(hcat(ones(size(X, 1)), X), hcat(ones(size(Z, 1)), Z),true, true)))
 # MLMEst.data.predictors.hasXIntercept -> false
 # MLMEst.data.predictors.hasZIntercept -> false
 
@@ -74,7 +74,7 @@ Ŷpredict3 = MatrixLM.predict(MLMEst, Predictors(hcat(ones(size(X, 1)), X), hca
 @testset "resid_test" begin
     @test isapprox(sum(Ŷpredict_a - Ŷpredict2), 0, atol = 0.1 )
     @test isapprox(sum(Ŷpredict_b - Ŷpredict3), 0, atol = 0.1 )
-    @test default_resids == residuals2
+    @test default_resids == resids2
 end
 
 #########################################
@@ -101,14 +101,14 @@ end
 
 @testset "calc_resid!" begin
     expected_resid = MatrixLM.calc_resid(X, Y, Z, B)
-    resid = similar(expected_resid)
-    fill!(resid, NaN)
+    resids = similar(expected_resid)
+    fill!(resids, NaN)
 
-    returned = MatrixLM.calc_resid!(resid, X, Y, Z, B)
+    returned = MatrixLM.calc_resid!(resids, X, Y, Z, B)
 
-    @test returned === resid
-    @test resid ≈ expected_resid atol = tol
+    @test returned === resids
+    @test resids ≈ expected_resid atol = tol
 
-    wrong_shape = Array{Float64}(undef, size(resid, 1) + 1, size(resid, 2))
+    wrong_shape = Array{Float64}(undef, size(resids, 1) + 1, size(resids, 2))
     @test_throws DimensionMismatch MatrixLM.calc_resid!(wrong_shape, X, Y, Z, B)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@
 # Library #
 ###########
 
+using Aqua
 using MatrixLM, LinearAlgebra, GLM
 using DataFrames 
 using Random, StatsModels, Statistics, Distributions
@@ -14,6 +15,9 @@ using Test
 
 
 @testset "MatrixLM" begin 
+    @testset "Aqua" begin
+        Aqua.test_all(MatrixLM)
+    end
     include("mlm_test.jl")
     include("misc_helpers_test.jl")
     include("shrink_sigma_test.jl")
@@ -25,4 +29,3 @@ using Test
     include("calc_sigma_test.jl")
     include("summary_test.jl")
 end
-

--- a/test/summary_test.jl
+++ b/test/summary_test.jl
@@ -35,7 +35,7 @@ using Statistics
     ci_upper_expected = est_coef .+ me_expected
 
     # 1 - Confint checks
-    ci_df = MatrixLM.confint(mlm_est; alpha = alpha)
+    ci_df = confint(mlm_est; alpha = alpha)
     @test ci_df.coefficient ≈ est_coef atol = tol
     @test ci_df.margin_of_error ≈ me_expected atol = tol
     @test ci_df.ci_lower ≈ ci_lower_expected atol = tol
@@ -71,7 +71,7 @@ using Statistics
     @test se ≈ glm_se atol = 1e-3  # allow a bit more tolerance for SEs
 
     # 5 - Confidence interval consistency with GLM 95% (symmetric z CI)
-    glm_ci = GLM.confint(glm_fit)  # columns: lower, upper
+    glm_ci = confint(glm_fit)  # columns: lower, upper
 
     @test round.(ci_df.ci_lower, digits = 3) ≈ round.(glm_ci[:, 1], digits = 3) atol = 1e-2
     @test round.(ci_df.ci_upper, digits = 3) ≈ round.(glm_ci[:, 2], digits = 3) atol = 1e-2


### PR DESCRIPTION
This PR adds a couple of things:
- Adds tests with Aqua.jl, which are really great at capturing some general quality issues
- Splits the author field in Project.toml up to be a list of multiple authors instead of a single author with a bunch of names 
- Adds compat bounds for stdlibs (strongly recommended)
- Bumps Julia compat to 1.10. This is what you're testing on, and the other compat bounds means that you can't run on Julia 1.0 or 1.6 (which I tried)
- updates all the CI files to use current action versions, julia caching, and restricted permissions. I also took advantage of this version bump and the julia compat change to replace an explicit lower bound in CI with 'min'
- Make `predict`, `residuals`, `coef`, `fitted`, and `confint` *methods* of the corresponding functions in StatsAPI. It's more Julian to distinguish things based on _dispatch_, i.e. the types of the arguments, than on explicit qualification. Since you specialized your definitions for the types you own, you can take advantage of this and not get export collisions with e.g. GLM or StatsBase.  There are a few other functions that could also potentially be renamed to be methods of StatsAPI functions -- `getX` could be a method of `StatsAPI.modelmatrix`.
- I dropped the compat entry for StatsModels 1.0 since that hasn't been released yet and is technically allowed to break from current behavior.