### PR TITLE
Integrate targetType = "R" - correlation/variance shrinkage into MatrixLM

### DIFF
--- a/docs/src/varShrinkage_example.md
+++ b/docs/src/varShrinkage_example.md
@@ -1,0 +1,241 @@
+```@meta
+ShareDefaultModule = true
+```
+
+# Variance Shrinkage
+
+## Overview
+
+In this section, we demonstrate how to use variance shrinkage when fitting a matrix linear model with `MatrixLM.jl`.
+
+Within the matrix linear model framework,
+
+$$
+Y = XBZ^T + E,
+$$
+
+where
+
+- ``Y_{n \times m}`` is the response matrix,
+- ``X_{n \times p}`` is the row-predictor matrix,
+- ``Z_{m \times q}`` is the response-attribute matrix,
+- ``B_{p \times q}`` is the coefficient matrix, and
+- ``E_{n \times m}`` is the error matrix.
+
+The rows of ``E`` are assumed to have covariance matrix ``\Sigma`` across the ``m`` responses. Estimating ``\Sigma`` directly from the residuals can be unstable when the number of responses is large relative to the sample size.
+Variance shrinkage stabilizes this estimate by shrinking noisy sample quantities toward structured targets using the analytic shrinkage procedures proposed by Schäfer and Strimmer (2005)[^1] and Opgen-Rhein and Strimmer (2007)[^2].
+
+`MatrixLM.jl` provides a simple Boolean interface for this choice:
+
+```julia
+mlm(data, false)  # no variance shrinkage
+mlm(data, true)   # use the a shrinkage estimator
+```
+
+When `varShrinkage=true`, `MatrixLM.jl` applies a shrinkage estimator, which separately shrinks transformed correlations and transformed variances toward their respective common targets.
+
+## Data Generation
+
+We begin by simulating data from a matrix linear model with correlated, heteroskedastic errors. This setting is useful for illustrating variance shrinkage because the response variables have both unequal variances and nonzero
+correlations.
+
+```@example varshrinkage
+using MatrixLM, LinearAlgebra, Random, Statistics
+Random.seed!(1)
+
+# Matrix dimensions
+n = 100
+m = 250
+p = 5
+q = 4
+
+# Row and column predictors
+X = randn(n, p)
+Z = randn(m, q)
+
+# True coefficient matrix
+B = [
+     1.5   0.0   0.5  -1.0;
+     0.0   1.0   0.0   0.5;
+    -0.5   0.0   1.5   0.0;
+     0.0  -1.0   0.5   1.0;
+     1.0   0.5   0.0   0.0
+]
+
+nothing #hide
+```
+
+To illustrate variance shrinkage, we generate an error matrix with correlated responses and unequal response variances. Correlation is introduced through a common random effect shared by all responses, while each response is assigned its own variance.
+
+```@example varshrinkage
+# Unequal response variances
+variances = range(0.5, 2.0, length=m)
+standard_deviations = sqrt.(variances)
+
+# Common correlation between responses
+rho = 0.6
+
+# Generate correlated, heteroskedastic errors
+common_noise = randn(n, 1)
+independent_noise = randn(n, m)
+
+E = (
+    sqrt(rho) .* common_noise .+
+    sqrt(1 - rho) .* independent_noise
+) .* reshape(standard_deviations, 1, m)
+
+# True covariance matrix
+R = fill(rho, m, m)
+R[diagind(R)] .= 1.0
+Dhalf = Diagonal(standard_deviations)
+Sigma_true = Dhalf * R * Dhalf
+
+# Generate the response matrix
+Y = X * B * Z' + E
+
+nothing #hide
+```
+Now construct a `RawData` object containing `Y`, `X`, and `Z`.
+
+```@example varshrinkage
+dat = RawData(
+    Response(Y),
+    Predictors(X, Z)
+)
+
+nothing #hide
+```
+
+## Model Estimation Without Variance Shrinkage
+
+Set the positional Boolean argument to `false` to estimate the residual covariance matrix without shrinkage.
+
+```@example varshrinkage
+est_no_shrinkage = mlm(
+    dat,
+    false;
+    addXIntercept=false,
+    addZIntercept=false
+)
+
+nothing #hide
+```
+
+The fitted object contains the coefficient estimates in `B`, the estimated error covariance matrix in `sigma`, and the coefficient variance estimates in `varB`.
+
+```@example varshrinkage
+size(est_no_shrinkage.B), size(est_no_shrinkage.sigma),
+size(est_no_shrinkage.varB)
+```
+
+## Model Estimation With Variance Shrinkage
+
+Set the positional Boolean argument to `true` to use the recommended variance shrinkage estimator.
+
+```@example varshrinkage
+est_shrinkage = mlm(
+    dat,
+    true;
+    addXIntercept=false,
+    addZIntercept=false
+)
+
+nothing #hide
+```
+
+The estimator separately shrinks
+
+1. Fisher-transformed sample correlations toward their common mean, and
+2. log-transformed sample variances toward their common mean.
+
+The fitted object records the estimated shrinkage intensities.
+
+```@example varshrinkage
+est_shrinkage.lambda
+```
+
+The returned `lambda` object contains separate shrinkage intensities for the correlation and variance components.
+
+## Comparing the Two Fits
+
+Variance shrinkage changes the estimated error covariance matrix and, consequently, the estimated variances and standard errors of the coefficients. It does not change the least-squares coefficient estimates.
+
+```@example varshrinkage
+maximum(abs.(est_no_shrinkage.B - est_shrinkage.B))
+```
+
+The covariance estimates generally differ:
+
+```@example varshrinkage
+covariance_difference =
+    norm(est_no_shrinkage.sigma - est_shrinkage.sigma)
+
+covariance_difference
+```
+
+The coefficient variance estimates can also differ because they depend on the estimated error covariance matrix:
+
+```@example varshrinkage
+coefficient_variance_difference =
+    norm(est_no_shrinkage.varB - est_shrinkage.varB)
+
+coefficient_variance_difference
+```
+
+For this simulated example, we can compare both covariance estimators with the known data-generating covariance matrix.
+
+```@example varshrinkage
+error_no_shrinkage =
+    norm(est_no_shrinkage.sigma - Sigma_true)
+
+error_shrinkage =
+    norm(est_shrinkage.sigma - Sigma_true)
+
+(
+    no_shrinkage = error_no_shrinkage,
+    R_shrinkage = error_shrinkage
+)
+```
+
+## Standard Errors and T-statistics
+
+The coefficient standard errors are obtained from `varB`.
+
+```@example varshrinkage
+se_no_shrinkage = sqrt.(est_no_shrinkage.varB)
+se_shrinkage = sqrt.(est_shrinkage.varB)
+```
+
+The corresponding t-statistics can be obtained with `t_stat`.
+
+```@example varshrinkage
+tstats_no_shrinkage = t_stat(est_no_shrinkage)
+tstats_shrinkage = t_stat(est_shrinkage)
+
+nothing #hide
+```
+
+Because variance shrinkage affects `varB`, it may also affect t-statistics, confidence intervals, and hypothesis-testing results.
+
+## Summary
+
+Variance shrinkage can be enabled in `MatrixLM.jl` by passing a Boolean as the second positional argument to `mlm`:
+
+```julia
+est = mlm(data, true)
+```
+
+The two principal calls are:
+
+```julia
+mlm(data, false)  # no variance shrinkage
+mlm(data, true)   # variance shrinkage
+```
+
+The estimator stabilizes the residual covariance estimate by separately shrinking transformed correlations and transformed variances. The resulting covariance estimate is stored in `est.sigma`, the coefficient variance estimates are stored in `est.varB`, and the estimated shrinkage intensities are stored in `est.lambda`.
+
+## References
+
+[^1]: Schäfer, J., & Strimmer, K. (2005). A shrinkage approach to large-scale covariance matrix estimation and implications for functional genomics. Statistical Applications in Genetics and Molecular Biology, 4(1). https://doi.org/10.2202/1544-6115.1175
+
+[^2]: Opgen-Rhein, R., & Strimmer, K. (2007). Accurate Ranking of Differentially Expressed Genes by a Distribution-Free Shrinkage Approach. Statistical Applications in Genetics and Molecular Biology, 6(1). https://doi.org/10.2202/1544-6115.1252

--- a/src/mlm.jl
+++ b/src/mlm.jl
@@ -43,6 +43,8 @@ shrinkage of the variance of the errors.
     - "B": Target is diagonal matrix with constant diagonal
     - "C": Target is has same diagonal element, and same off-diagonal element
     - "D": Target is diagonal matrix with unequal entries
+    - "R": Separately shrinks Fisher-transformed correlations and log-transformed 
+           variances toward their respective common means
 
 # Value
 
@@ -91,6 +93,8 @@ incorporates shrinkage of the variance of the errors.
     - "B": Target is diagonal matrix with constant diagonal
     - "C": Target is has same diagonal element, and same off-diagonal element
     - "D": Target is diagonal matrix with unequal entries
+    - "R": Separately shrinks Fisher-transformed correlations and log-transformed 
+           variances toward their respective common means
 
 # Value
 
@@ -194,6 +198,60 @@ function mlm(data::RawData; addXIntercept::Bool=true, addZIntercept::Bool=true,
     
     # Run matrix linear models
     return mlm_fit(data, weights, targetType)
+end
+
+"""
+    mlm(
+        data::RawData,
+        varShrinkage::Bool;
+        addXIntercept::Bool=true,
+        addZIntercept::Bool=true,
+        weights=nothing
+    )
+
+Fit a matrix linear model, with optional shrinkage estimation of the error
+covariance matrix.
+
+This method provides a simplified interface for selecting variance shrinkage.
+
+# Arguments
+
+- `data::RawData`: A `RawData` object containing the response and predictor
+  matrices.
+- `varShrinkage::Bool`: Whether to apply variance shrinkage.
+    - `false`: No variance shrinkage is performed.
+    - `true`: The `"R"` variance shrinkage estimator is used.
+
+# Keyword arguments
+
+- `addXIntercept::Bool`: Whether to include an intercept in `X`, corresponding
+  to row main effects. Defaults to `true`.
+- `addZIntercept::Bool`: Whether to include an intercept in `Z`, corresponding
+  to column main effects. Defaults to `true`.
+- `weights`: A vector of column weights for `Y`, or `nothing`. Defaults to
+  `nothing`.
+
+# Value
+
+An `Mlm` object.
+"""
+
+function mlm(data::RawData, varShrinkage::Bool; addXIntercept::Bool=true, addZIntercept::Bool=true, weights=nothing, kwargs...)
+
+    if varShrinkage
+        targetType = "R"
+    else
+        targetType = nothing
+    end
+
+    return mlm(
+        data;
+        addXIntercept=addXIntercept,
+        addZIntercept=addZIntercept,
+        weights=weights,
+        targetType=targetType,
+        kwargs...
+    )
 end
 
 """

--- a/src/mlm.jl
+++ b/src/mlm.jl
@@ -1,6 +1,6 @@
 """
     Mlm(B::Array{Float64,2}, varB::Array{Float64,2}, sigma::Array{Float64,2},    
-        data::RawData, weights, targetType, lambda::Float64)
+        data::RawData, weights, targetType, lambda)
 
 Type for storing the results of an mlm model fit. 
 
@@ -22,7 +22,7 @@ mutable struct Mlm
     # String indicating target type to shrink the variance toward, or `nothing`
     targetType 
     # Estimated shrinkage coefficient
-    lambda::Float64 
+    lambda 
 end
 
 
@@ -158,6 +158,8 @@ and shrinkage of the variance of the errors are options.
     - "B": Target is diagonal matrix with constant diagonal
     - "C": Target is has same diagonal element, and same off-diagonal element
     - "D": Target is diagonal matrix with unequal entries
+    - "R": Separately shrinks Fisher-transformed correlations and log-transformed 
+           variances toward their respective common means
 
 # Value
 
@@ -185,7 +187,7 @@ function mlm(data::RawData; addXIntercept::Bool=true, addZIntercept::Bool=true,
         data.q = data.q + 1
     end
     
-    if (typeof(targetType) != Nothing) & !(targetType in ["A", "B", "C", "D"])
+    if (typeof(targetType) != Nothing) & !(targetType in ["A", "B", "C", "D", "R"])
         println("Unrecognizable targetType will be ignored and no variance shrinkage will be performed.")
         targetType = nothing
     end

--- a/src/mlm_helpers.jl
+++ b/src/mlm_helpers.jl
@@ -1,5 +1,4 @@
 """
-
     calc_coeffs(X::AbstractArray{Float64,2}, Y::AbstractArray{Float64,2}, 
                 Z::AbstractArray{Float64,2}, XTX::AbstractArray{Float64,2}, 
                 ZTZ::AbstractArray{Float64,2})
@@ -73,18 +72,21 @@ shrinkage.
 
 - `resid::AbstractArray{Float64,2}`: 2d array of floats consisting of the residuals
 - `targetType::AbstractString`: Indicating the target type toward which to shrink the 
-  variance. Acceptable inputs are "A", "B", "C", and "D". 
+  variance. Acceptable inputs are "A", "B", "C", "D", and "R". 
     - "A": Target is identity matrix
     - "B": Target is diagonal matrix with constant diagonal
     - "C": Target is has same diagonal element, and same off-diagonal element
     - "D": Target is diagonal matrix with unequal entries
+    - "R": Separately shrinks transformed correlations and transformed
+           variances toward their respective common means
 
 # Value
 
 Tuple
 - `sigma`: 2d array of floats; shrunk estimated variance of errors
-- `lambda`: floating scalar; estimated shrinkage coefficient 
-  (0 = no shrinkage, 1 = complete shrinkage)
+- `lambda`: For targets `"A"`–`"D"`, a floating-point scalar.
+            For target `"R"`, a named tuple containing correlation and variance
+            shrinkage coefficients.
 
 """
 function calc_sigma(resid::AbstractArray{Float64,2}, 

--- a/src/shrink_sigma.jl
+++ b/src/shrink_sigma.jl
@@ -295,8 +295,8 @@ function shrink_var(X::Matrix{Float64})
     r = atanh.(r)
     v = log.(vec(var(X,dims=1)))
 
-    (λr,r) = shrink(r,mean(r),vr)
-    (λv,v) = shrink(v,mean(v),vv)
+    (r, λr) = shrink(r,mean(r),vr)
+    (v, λv) = shrink(v,mean(v),vv)
 
     r[:] = tanh.(r)
     v[:] = exp.(v.+0.5.*(var(v).+mean(vv)))

--- a/src/shrink_sigma.jl
+++ b/src/shrink_sigma.jl
@@ -146,3 +146,172 @@ function shrink_sigma(resid::AbstractArray{Float64,2}, targetType::String)
         
     return lambda*T + (1-lambda)*est, lambda
 end
+
+# ----------------------------------------------------------------------
+
+"""
+    tri2vec(X::Matrix{Float64}
+
+Extracts the diagonal and the upper triangular elements of a square
+matrix into two vectors.
+
+# Value
+
+A tuple of two vectors with the off diagonal and diagonal
+respectively.
+
+# See also
+
+`tri2vec`
+"""
+function tri2vec(X::Matrix{Float64})
+    m = size(X,1)
+    if(size(X,2)!=m)
+        error("Matrix not square.")
+    end
+    x = zeros(div(m*(m-1),2))
+    d = zeros(m)
+    
+    idx = 1
+    for i in 1:(m-1)
+        for j in ((i+1):m)
+            x[idx] = X[i,j]
+            idx+=1
+        end
+    end
+
+    for i in 1:m
+        d[i] = X[i,i]
+    end
+    return (x,d)
+end
+
+"""
+    vec2tri(X::Matrix{Float64}
+
+Reconstructs a square matrix from two vectors which are the upper
+triangular elements and the diagonal respectively.
+
+# Value
+
+Square symmetric matrix.
+
+# See also
+
+`vec2tri`
+"""
+function vec2tri(x::Vector{Float64},d::Vector{Float64})
+    m = (isqrt(8*length(x)+1)+1) ÷ 2
+    X = zeros(m,m)
+
+    if( m!=length(d) )
+        error("Incompatible dimensions of the two vectors.")
+    end
+    
+    idx = 1
+    for i in 1:(m-1)
+        for j in (i+1):m
+            X[i,j] = X[j,i] =  x[idx]
+            idx+=1
+        end
+    end
+
+    for i in 1:m
+        X[i,i] = d[i]
+    end
+    
+    return X
+end
+
+"""
+    shrink(x::Vector{Float64},t::Float64=0.0,v::Float64=1.0)
+
+Calculates shrinkage estimates based on estimates and their variances
+towards a target.
+
+# Arguments
+
+- `x::Vector{Float64}`: Vector of estimates
+- `t::Float64=0`: Target to shrink to
+- `v::Float64=1.0`: Common variance of the estimates
+
+# Value
+
+Tuple:
+- `x::Vector{Float64}`: Shrunk estimates
+- `λ:Float64`: Shrinkage coefficient (0=no shrinkage; 1=complete shrinkage) 
+
+"""
+function shrink(x::Vector{Float64},t::Float64=0.0,v::Float64=1.0)
+    k = length(x)
+    λ = k*v / sum((x .- t).^2)
+    λ = minimum((1.0,λ))
+    return λ*t .+ (1-λ) .* x, λ
+end
+
+"""
+    shrink_var(resid::Matrix{Float64})
+
+Estimates covariance matrix of residuals using a shrinkage estimator
+
+# Arguments
+
+- `resid::Matrix{Flaot64}`: 2d array of floats consisting of the residuals
+
+# Value
+
+Tuple
+- `sigma`: 2d array of floats; shrunk estimated variance of errors
+- `lambda`: floating scalar; estimated shrinkage coefficient 
+  (0 = no shrinkage, 1 = complete shrinkage)
+
+# Details
+
+The covariance matrix is decomposed into a correlation matrix and a variance
+vector.  They are each transformed by a variance stabilizing transform and
+shrunk towards a common value. Then they are transformed back and the
+covariance matrix is reconstructed.
+
+# Reference
+
+Ledoit, O., & Wolf, M. (2003). Improved estimation of the covariance matrix 
+    of stock returns with an application to portfolio selection. Journal of 
+    empirical finance, 10(5), 603-621.
+
+"""
+function shrink_var(X::Matrix{Float64})
+
+    (n,m) = size(X) # number of samples
+    if (n<=3) 
+        error("Sample size too small for proceeding further.")
+    end
+
+    # variance of correlation and variance after variance stabilizing transform
+    vr = 1/(n-3)
+    vv = 2/(n-2)
+
+    
+    (r,a) = tri2vec(cor(X))
+    r = atanh.(r)
+    v = log.(vec(var(X,dims=1)))
+
+    (λr,r) = shrink(r,mean(r),vr)
+    (λv,v) = shrink(v,mean(v),vv)
+
+    r[:] = tanh.(r)
+    v[:] = exp.(v.+0.5.*(var(v).+mean(vv)))
+    s = sqrt.(v)
+
+    R = vec2tri(r,a)
+    
+    S = Diagonal(s) * R * Diagonal(s)
+    
+end
+
+# checks to perform
+
+# - tri2vec and vec2tri should be inverses of each other
+# - tri2vec should only work for square matrices
+# - vec2tri should have compatible argument lengths
+# - shrunk covariance should be positive definite even if input is not
+

--- a/src/shrink_sigma.jl
+++ b/src/shrink_sigma.jl
@@ -77,78 +77,6 @@ function cov_est(resid::AbstractArray{Float64,2})
     return est, varEst
 end
 
-
-"""
-    shrink_sigma(resid::AbstractArray{Float64,2}, targetType::String)
-
-Estimates variance of errors and the shrinkage coefficient
-
-# Arguments
-
-- `resid::AbstractArray{Float64,2}`: 2d array of floats consisting of the residuals
-- `targetType::String`: string indicating the target type toward which to shrink the 
-  variance. Acceptable inputs are "A", "B", "C", and "D". 
-    - "A": Target is identity matrix
-    - "B": Target is diagonal matrix with constant diagonal
-    - "C": Target is has same diagonal element, and same off-diagonal element
-    - "D": Target is diagonal matrix with unequal entries
-
-# Value
-
-Tuple
-- `sigma`: 2d array of floats; shrunk estimated variance of errors
-- `lambda`: floating scalar; estimated shrinkage coefficient 
-  (0 = no shrinkage, 1 = complete shrinkage)
-
-# Reference
-
-Ledoit, O., & Wolf, M. (2003). Improved estimation of the covariance matrix 
-    of stock returns with an application to portfolio selection. Journal of 
-    empirical finance, 10(5), 603-621.
-
-"""
-function shrink_sigma(resid::AbstractArray{Float64,2}, targetType::String)
-    
-    # Dimensions of resid
-    (n, p) = size(resid)
-    
-    # Estimates and the variance of the error variance
-    (est, varEst) = cov_est(resid)
-    
-    if targetType=="A"  # Shrink to identity
-        # Create identity target matrix
-        T = Matrix{Float64}(I, p, p)
-        # Estimate optimal lambda
-        lambda = sum(varEst) / sum((est-T).^2)
-        
-    elseif targetType=="B"  # Shrink to common variance
-        # Create target matrix
-        T = Matrix{Float64}(I, p, p) * mean(diag(est))
-        # Estimate optimal lambda
-        lambda = sum(varEst) / sum((est-T).^2)
-        
-    elseif targetType=="C"  # Shrink to equal variance and covariance
-        v = mean(diag(est))
-        c = (sum(est) - sum(diag(est))) / (n*(n-1))
-        # Create target matrix
-        T = fill(c,(p,p)) + (v-c) * Matrix{Float64}(I, p, p)
-        # Estimate optimal lambda
-        lambda = sum(varEst) / sum((est-T).^2)
-        
-    elseif targetType=="D"  # Shrink to zero correlation
-        v = diag(est)
-        # Create target matrix
-        T = diagm(0 => v)
-        # Estimate optimal lambda
-        lambda = (sum(varEst) - sum(diag(varEst))) /
-                 (sum(est.^2) - sum(diag(est).^2))
-    end
-        
-    return lambda*T + (1-lambda)*est, lambda
-end
-
-# ----------------------------------------------------------------------
-
 """
     tri2vec(X::Matrix{Float64}
 
@@ -262,8 +190,10 @@ Estimates covariance matrix of residuals using a shrinkage estimator
 
 Tuple
 - `sigma`: 2d array of floats; shrunk estimated variance of errors
-- `lambda`: floating scalar; estimated shrinkage coefficient 
-  (0 = no shrinkage, 1 = complete shrinkage)
+- `lambda`: For targets "A"–"D", a floating-point scalar. 
+            For target "R", a named tuple containing:
+            - `correlation`: correlation shrinkage coefficient
+            - `variance`: variance shrinkage coefficient
 
 # Details
 
@@ -279,7 +209,7 @@ Ledoit, O., & Wolf, M. (2003). Improved estimation of the covariance matrix
     empirical finance, 10(5), 603-621.
 
 """
-function shrink_var(X::Matrix{Float64})
+function shrink_var(X::AbstractMatrix{Float64})
 
     (n,m) = size(X) # number of samples
     if (n<=3) 
@@ -305,8 +235,103 @@ function shrink_var(X::Matrix{Float64})
     R = vec2tri(r,a)
     
     S = Diagonal(s) * R * Diagonal(s)
+
+    return S, (correlation = λr, variance = λv)
     
 end
+
+
+"""
+    shrink_sigma(resid::AbstractArray{Float64,2}, targetType::String)
+
+Estimates variance of errors and the shrinkage coefficient
+
+# Arguments
+
+- `resid::AbstractArray{Float64,2}`: 2d array of floats consisting of the residuals
+- `targetType::String`: string indicating the target type toward which to shrink the 
+  variance. Acceptable inputs are "A", "B", "C", and "D". 
+    - "A": Target is identity matrix
+    - "B": Target is diagonal matrix with constant diagonal
+    - "C": Target is has same diagonal element, and same off-diagonal element
+    - "D": Target is diagonal matrix with unequal entries
+    - "R": Separately shrinks Fisher-transformed correlations and log-transformed 
+             variances toward their respective common means
+
+# Value
+
+Tuple
+- `sigma`: 2d array of floats; shrunk estimated variance of errors
+- `lambda`: For targets "A"–"D", a floating-point scalar.
+            For target "R", a named tuple containing:
+            - `correlation`: correlation shrinkage coefficient
+            - `variance`: variance shrinkage coefficient
+
+
+# Reference
+
+Ledoit, O., & Wolf, M. (2003). Improved estimation of the covariance matrix 
+    of stock returns with an application to portfolio selection. Journal of 
+    empirical finance, 10(5), 603-621.
+
+"""
+function shrink_sigma(resid::AbstractArray{Float64,2}, targetType::String)
+    
+    if targetType == "R"
+        return shrink_var(resid)
+    end
+
+    # Dimensions of resid
+    (n, p) = size(resid)
+    
+    # Estimates and the variance of the error variance
+    (est, varEst) = cov_est(resid)
+    
+    if targetType=="A"  # Shrink to identity
+        # Create identity target matrix
+        T = Matrix{Float64}(I, p, p)
+        # Estimate optimal lambda
+        lambda = sum(varEst) / sum((est-T).^2)
+        
+    elseif targetType=="B"  # Shrink to common variance
+        # Create target matrix
+        T = Matrix{Float64}(I, p, p) * mean(diag(est))
+        # Estimate optimal lambda
+        lambda = sum(varEst) / sum((est-T).^2)
+        
+    elseif targetType=="C"  # Shrink to equal variance and covariance
+        v = mean(diag(est))
+        c = (sum(est) - sum(diag(est))) / (n*(n-1))
+        # Create target matrix
+        T = fill(c,(p,p)) + (v-c) * Matrix{Float64}(I, p, p)
+        # Estimate optimal lambda
+        lambda = sum(varEst) / sum((est-T).^2)
+        
+    elseif targetType=="D"  # Shrink to zero correlation
+        v = diag(est)
+        # Create target matrix
+        T = diagm(0 => v)
+        # Estimate optimal lambda
+        lambda = (sum(varEst) - sum(diag(varEst))) /
+                 (sum(est.^2) - sum(diag(est).^2))
+    
+    else
+        throw(
+            ArgumentError(
+                "Unrecognized targetType \"$targetType\". " *
+                "Valid options are \"A\", \"B\", \"C\", \"D\", and \"R\"."
+            )
+        )
+
+    end
+        
+    return lambda*T + (1-lambda)*est, lambda
+    
+end
+
+# ----------------------------------------------------------------------
+
+
 
 # checks to perform
 

--- a/test/mlm_test.jl
+++ b/test/mlm_test.jl
@@ -45,8 +45,42 @@ fresh_raw() = RawData(Response(copy(Y)), Predictors(copy(X), copy(Z)))
     #@test LinearAlgebra.issymmetric(round.(MLMEst.sigma, digits=10))
 end
 
+@testset "mlm targetType R integration" begin
+    MLMEst_R = mlm(
+        fresh_raw();
+        addXIntercept = false,
+        addZIntercept = false,
+        targetType = "R"
+    )
 
-MLMEst_w = mlm(MLMData_w, weights = w , addXIntercept = true, addZIntercept = false, targetType = 'E')
+    # Confirm that the requested target type is retained
+    @test MLMEst_R.targetType == "R"
+
+    # The residual covariance should have one row and column
+    # for each response variable
+    @test size(MLMEst_R.sigma) == (m, m)
+
+    # The covariance estimate should be symmetric and positive definite
+    @test isapprox(MLMEst_R.sigma, MLMEst_R.sigma', atol=tol)
+    @test isposdef(Symmetric(MLMEst_R.sigma))
+
+    # The R estimator should return two named shrinkage coefficients
+    @test MLMEst_R.lambda isa NamedTuple
+    @test hasproperty(MLMEst_R.lambda, :correlation)
+    @test hasproperty(MLMEst_R.lambda, :variance)
+
+    # Both shrinkage coefficients should lie between zero and one
+    @test 0.0 <= MLMEst_R.lambda.correlation <= 1.0
+    @test 0.0 <= MLMEst_R.lambda.variance <= 1.0
+
+    # Confirm that ordinary model outputs are still produced
+    @test size(MLMEst_R.B) == (p, q)
+    @test size(MLMEst_R.varB) == (p, q)
+
+end
+
+
+MLMEst_w = mlm(MLMData_w, weights = w , addXIntercept = true, addZIntercept = false, targetType = "E")
 GLMData_w = DataFrame(hcat(vec(Yw), kron(WZ,X)), :auto)
 GLMEst_w = lm(Matrix(GLMData_w[:,2:end]), Vector(GLMData_w[:,1]))
 

--- a/test/mlm_test.jl
+++ b/test/mlm_test.jl
@@ -79,6 +79,53 @@ end
 
 end
 
+@testset "mlm Boolean variance shrinkage interface" begin
+    # varShrinkage = false should be equivalent to targetType = nothing
+    MLMEst_false = mlm(
+        fresh_raw(),
+        false;
+        addXIntercept = false,
+        addZIntercept = false
+    )
+
+    MLMEst_none = mlm(
+        fresh_raw();
+        addXIntercept = false,
+        addZIntercept = false,
+        targetType = nothing
+    )
+
+    @test MLMEst_false.targetType === nothing
+    @test MLMEst_none.targetType === nothing
+
+    @test isapprox(MLMEst_false.B, MLMEst_none.B, atol=tol)
+    @test isapprox(MLMEst_false.sigma, MLMEst_none.sigma, atol=tol)
+    @test isapprox(MLMEst_false.varB, MLMEst_none.varB, atol=tol)
+
+    # varShrinkage = true should be equivalent to targetType = "R"
+    MLMEst_true = mlm(
+        fresh_raw(),
+        true;
+        addXIntercept = false,
+        addZIntercept = false
+    )
+
+    MLMEst_R = mlm(
+        fresh_raw();
+        addXIntercept = false,
+        addZIntercept = false,
+        targetType = "R"
+    )
+
+    @test MLMEst_true.targetType == "R"
+    @test MLMEst_R.targetType == "R"
+
+    @test isapprox(MLMEst_true.B, MLMEst_R.B, atol=tol)
+    @test isapprox(MLMEst_true.sigma, MLMEst_R.sigma, atol=tol)
+    @test isapprox(MLMEst_true.varB, MLMEst_R.varB, atol=tol)
+    @test MLMEst_true.lambda == MLMEst_R.lambda
+end
+
 
 MLMEst_w = mlm(MLMData_w, weights = w , addXIntercept = true, addZIntercept = false, targetType = "E")
 GLMData_w = DataFrame(hcat(vec(Yw), kron(WZ,X)), :auto)

--- a/test/shrink_sigma_test.jl
+++ b/test/shrink_sigma_test.jl
@@ -38,3 +38,38 @@ lambdaD = MatrixLM.shrink_sigma(X, "D")[2]
     @test isapprox(lambdaB, lambdaD, atol=0.1)
     @test isapprox(lambdaC, lambdaD, atol= 0.1)
 end;
+
+@testset "tri2vec and vec2tri checks" begin
+        A = [1.0 0.2 0.3;
+             0.2 2.0 0.4;
+             0.3 0.4 3.0]
+
+    x, d = MatrixLM.tri2vec(A)
+    A_reconstructed = MatrixLM.vec2tri(x, d)
+    @test isapprox(A_reconstructed, A, atol=tol)
+end;
+
+@testset "tri2vec rejects non-square matrices" begin
+    A = randn(3, 4)
+    @test_throws ErrorException MatrixLM.tri2vec(A)
+
+end;
+
+@testset "vec2tri rejects incompatible dimensions" begin
+    x = [0.1, 0.2, 0.3]   # corresponds to off-diagonal entries of a 3x3 matrix
+    d = [1.0, 2.0]        # wrong diagonal length
+    @test_throws ErrorException MatrixLM.vec2tri(x, d)
+end;
+
+@testset "shrink_var returns positive definite covariance matrix" begin
+
+    Random.seed!(123)
+    # n < p to to make sample covariance singular/noisy
+    X_hd = randn(10, 25)
+
+    S = MatrixLM.shrink_var(X_hd)
+    
+    @test size(S) == (25, 25)
+    @test isapprox(S, S', atol=tol)
+    @test isposdef(S)
+end;

--- a/test/shrink_sigma_test.jl
+++ b/test/shrink_sigma_test.jl
@@ -16,7 +16,7 @@ q = 20
 Random.seed!(4)
 X = rand(n,p)
     
-m = mean(X, dims=1)
+X_mean = mean(X, dims=1)
 est, varEst = MatrixLM.cov_est(X)
 lambda = MatrixLM.shrink_sigma(X, "A")[2]
 T = Matrix{Float64}(I, p, p)
@@ -64,12 +64,55 @@ end;
 @testset "shrink_var returns positive definite covariance matrix" begin
 
     Random.seed!(123)
-    # n < p to to make sample covariance singular/noisy
+
+    # n < p to make the sample covariance singular/noisy
     X_hd = randn(10, 25)
 
-    S = MatrixLM.shrink_var(X_hd)
-    
+    S, lambdaR = MatrixLM.shrink_var(X_hd)
+
     @test size(S) == (25, 25)
     @test isapprox(S, S', atol=tol)
-    @test isposdef(S)
+    @test isposdef(Symmetric(S))
+
+    @test lambdaR isa NamedTuple
+    @test hasproperty(lambdaR, :correlation)
+    @test hasproperty(lambdaR, :variance)
+
+    @test 0.0 <= lambdaR.correlation <= 1.0
+    @test 0.0 <= lambdaR.variance <= 1.0
+end;
+
+@testset "shrink_sigma target R routing" begin
+
+    Random.seed!(124)
+    X_R = randn(20, 12)
+
+    S_direct, lambda_direct = MatrixLM.shrink_var(X_R)
+    S_routed, lambda_routed = MatrixLM.shrink_sigma(X_R, "R")
+
+    @test isapprox(S_routed, S_direct, atol=tol)
+
+    @test isapprox(
+        lambda_routed.correlation,
+        lambda_direct.correlation,
+        atol=tol
+    )
+
+    @test isapprox(
+        lambda_routed.variance,
+        lambda_direct.variance,
+        atol=tol
+    )
+
+    @test isposdef(S_routed)
+end;
+
+@testset "shrink_sigma rejects invalid target" begin
+
+    X_invalid = randn(20, 5)
+
+    @test_throws ArgumentError MatrixLM.shrink_sigma(
+        X_invalid,
+        "invalid"
+    )
 end;


### PR DESCRIPTION
This PR integrates the new correlation/variance shrinkage estimator into MatrixLM through targetType="R".

Changes include

added targetType="R" routing through shrink_sigma()
integrated shrink_var() into MatrixLM
updated Mlm object to support the new shrinkage output
updated documentation
added unit tests
added integration tests
All package tests pass.