### PR TITLE
Add Variance Shrinkage Documentation and Prepare Version 1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatrixLM"
 uuid = "37290134-6146-11e9-0c71-a5c489be1f53"
-version = "0.3.1"
-authors = ["Jane Liang", "Gregory Farage", "Chenhao Zhao", "Saunak Sen"]
+version = "1.0.0"
+authors = ["Jane Liang", "Gregory Farage", "Chenhao Zhao", "Harsh Vardhan Dubey", "Saunak Sen"]
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(; modules=[MatrixLM], sitename="MatrixLM.jl", pages=[
         "Home" => "index.md",
         "Getting Started" => "getting_started.md",
         "Example: MLM for ordinal predictors" => "example_ordinal_data.md",
+        "Variance Shrinkage with MatrixLM.jl" => "varShrinkage_example.md",
         "Types and Functions" => "functions.md",
     ]
 )

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -76,7 +76,7 @@ please refer to the documentation for [contrast coding with StatsModels.jl](http
 This provides comprehensive instructions and examples.
 
 ```@example
-# Convert dataframe to predicton matrix
+# Convert dataframe to prediction matrix
 my_ctrst = Dict(
              :catvar1 => DummyCoding(base = "0"),
              :catvar2 => DummyCoding(base = "A")

--- a/docs/src/varShrinkage_example.md
+++ b/docs/src/varShrinkage_example.md
@@ -10,9 +10,7 @@ In this section, we demonstrate how to use variance shrinkage when fitting a mat
 
 Within the matrix linear model framework,
 
-$$
-Y = XBZ^T + E,
-$$
+$$Y = XBZ^T + E,$$
 
 where
 

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -96,7 +96,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Convert dataframe to predicton matrix\n",
+    "# Convert dataframe to prediction matrix\n",
     "my_ctrst = Dict(\n",
     "             :catvar1 => DummyCoding(base = \"0\"),\n",
     "             :catvar2 => DummyCoding(base = \"A\")\n",


### PR DESCRIPTION
This PR:

* Updates `make.jl` to include the new **“Example: Variance Shrinkage with MatrixLM.jl”** page in the documentation.
* Adds **Harsh Dubbey** as an author.
* Updates the package version to **1.0.0**.
