### PR TITLE
v1.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ GLM = "1.8"
 LinearAlgebra = "1"
 Random = "1"
 SharedArrays = "1"
+StableRNGs = "^1.0.1"
 Statistics = "1"
 StatsAPI = "1.8.0"
 StatsModels = "0.6, 0.7"
@@ -35,7 +36,8 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "GLM", "Test"]
+test = ["Aqua", "GLM", "StableRNGs", "Test"]

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -20,6 +20,18 @@ Where
 - ``E_{n \times m}`` is the error term, 
 - ``B_{p \times q}`` is the matrix for main and interaction effects.
 
+The elements of $B$ may be interpreted as interactions between
+the columns of $X$ and the columns of $Z$. The residuals are assumed
+to have mean zero, to be independent across samples, and to have a 
+covariance $\Sigma$ across the features, $$V(\hbox{vec}(E)) = \Sigma \otimes I.$$
+Thus, the model allows features within a sample to be correlated while 
+treating the samples as independent.
+
+The current implementation of MatrixLM.jl requires complete response
+and predictor matrices. Missing data should therefore be addressed before
+model fitting using a method appropriate for the assumed missingness
+mechanism and the structure of the data.
+
 
 ## Data Generation
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -27,6 +27,13 @@ covariance $\Sigma$ across the features, $$V(\hbox{vec}(E)) = \Sigma \otimes I.$
 Thus, the model allows features within a sample to be correlated while 
 treating the samples as independent.
 
+The covariance matrix $\Sigma$ is estimated from the empirical covariance 
+matrix of the residuals. When the number of features is comparable to or greater 
+than the number of samples, the empirical covariance estimate may be singular. 
+MatrixLM.jl therefore provides the option of using a shrinkage covariance estimator, 
+which produces a nonsingular estimate of $\Sigma$. The shrinkage target can be specified 
+using the `targetType` argument.
+
 The current implementation of MatrixLM.jl requires complete response
 and predictor matrices. Missing data should therefore be addressed before
 model fitting using a method appropriate for the assumed missingness

--- a/src/shrink_sigma.jl
+++ b/src/shrink_sigma.jl
@@ -216,7 +216,8 @@ function shrink_var(X::AbstractMatrix{Float64})
     
     (r,a) = tri2vec(cor(X))
     r = atanh.(r)
-    v = log.(vec(var(X,dims=1)))
+    # v = log.(vec(var(X,dims=1))) # Failin on Julia nightly 2026-08-05
+    v = log.(map(var, eachcol(X)))
 
     (r, λr) = shrink(r,mean(r),vr)
     (v, λv) = shrink(v,mean(v),vv)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Aqua
 using MatrixLM, LinearAlgebra, GLM
 using DataFrames 
 using Random, StatsModels, Statistics, Distributions
+using StableRNGs
 using Test
 
 

--- a/test/shrink_sigma_test.jl
+++ b/test/shrink_sigma_test.jl
@@ -13,8 +13,8 @@ p = 10
 q = 20
     
 # Generate some matrices.
-Random.seed!(4)
-X = rand(n,p)
+rng = StableRNG(4)
+X = rand(rng, n, p)
     
 X_mean = mean(X, dims=1)
 est, varEst = MatrixLM.cov_est(X)
@@ -50,7 +50,8 @@ end;
 end;
 
 @testset "tri2vec rejects non-square matrices" begin
-    A = randn(3, 4)
+    rng = StableRNG(41)
+    A = randn(rng, 3, 4)
     @test_throws ErrorException MatrixLM.tri2vec(A)
 
 end;
@@ -63,10 +64,10 @@ end;
 
 @testset "shrink_var returns positive definite covariance matrix" begin
 
-    Random.seed!(123)
+    rng = StableRNG(123)
 
     # n < p to make the sample covariance singular/noisy
-    X_hd = randn(10, 25)
+    X_hd = randn(rng, 10, 25)
 
     S, lambdaR = MatrixLM.shrink_var(X_hd)
 
@@ -84,8 +85,8 @@ end;
 
 @testset "shrink_sigma target R routing" begin
 
-    Random.seed!(124)
-    X_R = randn(20, 12)
+    rng = StableRNG(124)
+    X_R = randn(rng, 20, 12)
 
     S_direct, lambda_direct = MatrixLM.shrink_var(X_R)
     S_routed, lambda_routed = MatrixLM.shrink_sigma(X_R, "R")
@@ -109,7 +110,8 @@ end;
 
 @testset "shrink_sigma rejects invalid target" begin
 
-    X_invalid = randn(20, 5)
+    rng = StableRNG(125)
+    X_invalid = randn(rng, 20, 5)
 
     @test_throws ArgumentError MatrixLM.shrink_sigma(
         X_invalid,
@@ -119,7 +121,8 @@ end;
 
 @testset "shrink_var rejects sample size <= 3" begin
 
-    X_small = randn(3, 5)
+    rng = StableRNG(126)
+    X_small = randn(rng, 3, 5)
 
     @test_throws ErrorException MatrixLM.shrink_var(X_small)
 end;


### PR DESCRIPTION
This PR includes:


## MatrixLM.jl v1.1.0

MatrixLM.jl v1.1.0 improves the readability, reproducibility, documentation, and testing of the package. The release introduces custom display methods for clearer result presentation, expands the documentation with intermediate outputs and real-data examples, and uses `StableRNGs.jl` to ensure reproducible documentation examples and `shrink_signa` tests. It also adds test coverage for the new display methods.

**Release:** [[MatrixLM.jl v1.1.0](https://github.com/senresearch/MatrixLM.jl/releases/tag/v1.1.0)](https://github.com/senresearch/MatrixLM.jl/releases/tag/v1.1.0)

**Included pull requests:**

* [[PR #60 — Improve documentation, display methods, and real-data examples](https://github.com/senresearch/MatrixLM.jl/pull/60)](https://github.com/senresearch/MatrixLM.jl/pull/60)
* [[PR #61 — Stabilize the random seed in shrinkage testing](https://github.com/senresearch/MatrixLM.jl/pull/61)](https://github.com/senresearch/MatrixLM.jl/pull/61)